### PR TITLE
Added removing invalid guide tag usage

### DIFF
--- a/src/PirateJim.cs
+++ b/src/PirateJim.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
 using SomeCatIDK.PirateJim.Services;
-using SomeCatIDK.PirateJim.src.Services;
 
 namespace SomeCatIDK.PirateJim;
 

--- a/src/PirateJim.cs
+++ b/src/PirateJim.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
 using SomeCatIDK.PirateJim.Services;
+using SomeCatIDK.PirateJim.src.Services;
 
 namespace SomeCatIDK.PirateJim;
 
@@ -37,6 +38,8 @@ public sealed class PirateJim
         _services.Add(new RatingChannelService(this));
         _services.Add(new SurvivorRoleService(this));
         _services.Add(new AutomaticMessageService(this));
+        var guideTagService = new RemoveInvalidGuideTagService(this);
+        _services.Add(guideTagService);
         
         await DiscordClient.LoginAsync(TokenType.Bot, Environment.GetEnvironmentVariable("PJ_TOKEN"));
         
@@ -45,7 +48,9 @@ public sealed class PirateJim
         await DiscordClient.SetGameAsync("V2 time!");
         
         await appealsService.InitializeAsync(this);
-        
+
+        await guideTagService.InitializeAsync();
+
         // Keep current Task alive to prevent program from closing.
         await Task.Delay(-1);
     }

--- a/src/Services/RemoveInvalidGuideTagService.cs
+++ b/src/Services/RemoveInvalidGuideTagService.cs
@@ -1,14 +1,12 @@
-﻿using Discord;
-using Discord.WebSocket;
-using SomeCatIDK.PirateJim.Model;
-using SomeCatIDK.PirateJim.Services;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using SomeCatIDK.PirateJim.Model;
 
-namespace SomeCatIDK.PirateJim.src.Services;
+namespace SomeCatIDK.PirateJim.Services;
 
 public class RemoveInvalidGuideTagService : IService
 {

--- a/src/Services/RemoveInvalidGuideTagService.cs
+++ b/src/Services/RemoveInvalidGuideTagService.cs
@@ -1,0 +1,77 @@
+﻿using Discord;
+using Discord.WebSocket;
+using SomeCatIDK.PirateJim.Model;
+using SomeCatIDK.PirateJim.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SomeCatIDK.PirateJim.src.Services;
+
+public class RemoveInvalidGuideTagService : IService
+{
+    private const string GuideTag = "Guide";
+
+    private Dictionary<ulong, ulong> _guideTagIds = new Dictionary<ulong, ulong>();
+
+    private readonly PirateJim _bot;
+
+    public RemoveInvalidGuideTagService(PirateJim bot)
+    {
+        _bot = bot;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await RegisterGuideTagAsync(UOChannels.ServerHosting);
+        await RegisterGuideTagAsync(UOChannels.UnturnedSupport);
+        await RegisterGuideTagAsync(UOChannels.ModdingSupport);
+
+        _bot.DiscordClient.ThreadCreated += OnThreadCreated;
+        _bot.DiscordClient.ThreadUpdated += OnThreadUpdated;
+    }
+
+    private async Task RegisterGuideTagAsync(ulong channelId)
+    {
+        var channel = await _bot.DiscordClient.GetChannelAsync(channelId);
+
+        if (channel is not IForumChannel forum)
+            return;
+
+        var tags = forum.Tags.ToList();
+        var tagIndex = tags.FindIndex(t => t.Name == GuideTag);
+
+        if (tagIndex == -1)
+            return;
+
+        _guideTagIds.Add(channelId, tags[tagIndex].Id);
+    }
+
+    private async Task OnThreadCreated(SocketThreadChannel post)
+    {
+        await RemoveInvalidGuideTagAsync(post);
+    }
+
+    private async Task OnThreadUpdated(Cacheable<SocketThreadChannel, ulong> cachedPost, SocketThreadChannel updatedPost)
+    {
+        await RemoveInvalidGuideTagAsync(updatedPost);
+    }
+
+    private async Task RemoveInvalidGuideTagAsync(SocketThreadChannel post)
+    {
+        if (!_guideTagIds.TryGetValue(post.ParentChannel.Id, out ulong guideTagId))
+            return;
+
+        if (!post.AppliedTags.Contains(guideTagId))
+            return;
+
+        if (post.Owner.GuildUser.GuildPermissions.ManageThreads)
+            return;
+
+        var newTags = post.AppliedTags.ToList();
+        newTags.Remove(guideTagId);
+        await post.ModifyAsync((post) => post.AppliedTags = newTags);
+    }
+}


### PR DESCRIPTION
Added a new service that removes the guide tag from new posts and post that are edited if the author doesn't have the manage threads permission.

Yes, this does mean that moderators with the manage threads permission can't add the guide tag to posts were the author doesn't have the permission. Can't seem to find a way to get the user who edited the post in `ThreadUpdated` so idk.
