### PR TITLE
More Fixes for SolvedPostsService

### DIFF
--- a/src/Services/SolvedPostsService.cs
+++ b/src/Services/SolvedPostsService.cs
@@ -1,5 +1,6 @@
 ﻿using Cottle;
 using Discord;
+using Discord.Rest;
 using Discord.WebSocket;
 using SomeCatIDK.PirateJim.Model;
 using SomeCatIDK.PirateJim.Services;
@@ -35,6 +36,8 @@ public class SolvedPostsService : IService, IInitializableService
 
     private readonly PirateJim _bot;
 
+    private ulong? _lastAuditLog;
+
     public SolvedPostsService(PirateJim bot)
     {
         _bot = bot;
@@ -54,6 +57,7 @@ public class SolvedPostsService : IService, IInitializableService
         await RegisterSolvedChannelAsync(moddingSupport);
 
         _bot.DiscordClient.ThreadCreated += OnUnsolvedSupportPostCreated;
+        _bot.DiscordClient.ThreadUpdated += OnIgnoreTagAdded;
         _bot.DiscordClient.ButtonExecuted += OnMarkAsSolvedButton;
         _bot.DiscordClient.ButtonExecuted += OnReopenButton;
         _bot.DiscordClient.MessageReceived += OnDeleteInactivePostNotification;
@@ -82,6 +86,7 @@ public class SolvedPostsService : IService, IInitializableService
         _ = Task.Run(() => NotifyInactivePosts(registeredChannel));
     }
 
+    #region Stale Forum Posts
     private async Task NotifyInactivePosts(RegisteredSolvedChannel solvedChannel)
     {
         var channel = await _bot.DiscordClient.GetChannelAsync(solvedChannel.SolvedChannel.ChannelId);
@@ -106,20 +111,37 @@ public class SolvedPostsService : IService, IInitializableService
         }
     }
 
-    private async Task OnDeleteInactivePostNotification(SocketMessage message) => await DeleteInactivePostNotification(message.Channel);
-    private async Task DeleteInactivePostNotification(IChannel channel)
+    private bool IsStaleNotificationMessage(IMessage message, RegisteredSolvedChannel solvedChannel)
     {
-        if (channel is not SocketThreadChannel thread || thread.ParentChannel is not SocketForumChannel forumChannel) return;
+        if (message.Author.Id != _bot.DiscordClient.CurrentUser.Id) return false;
+        if (message is IUserMessage userMessage && userMessage.InteractionMetadata != null) return false;
+        if (message.Components.Count != 0) return false;
+
+        return message.Embeds.Count > 0 && message.Embeds.First().Description == (solvedChannel.SolvedChannel.StaleDescription ?? StaleDefaultDescription);
+    }
+
+    private async Task OnDeleteInactivePostNotification(SocketMessage message)
+    {
+        if (message.Channel is not SocketThreadChannel thread || thread.ParentChannel is not SocketForumChannel forumChannel) return;
         if (thread.IsLocked || thread.IsArchived) return;
         if (!_registeredSolvedChannels.TryGetValue(forumChannel.Id, out var solvedChannel)) return;
+
+        if (IsStaleNotificationMessage(message, solvedChannel)) return;
+        await DeleteInactivePostNotification(thread, solvedChannel);
+    }
+
+    private async Task DeleteInactivePostNotification(SocketThreadChannel thread, RegisteredSolvedChannel solvedChannel)
+    {
+        if (thread.IsLocked || thread.IsArchived) return;
         if (thread.AppliedTags.Any(t => t == solvedChannel.SolvedTag || solvedChannel.IgnoreWithTags.Contains(t))) return;
 
         var messages = await thread.GetMessagesAsync(4).FlattenAsync();
-        var inactivePostMessage = messages.FirstOrDefault(m => m.Author.Id == _bot.DiscordClient.CurrentUser.Id && m.Reference == null && m.Embeds.Count > 0 && m.Components.Count == 0);
+        var inactivePostMessage = messages.FirstOrDefault(m => IsStaleNotificationMessage(m, solvedChannel));
         if (inactivePostMessage == null) return;
 
         await thread.DeleteMessageAsync(inactivePostMessage);
     }
+    #endregion // Stale Forum Posts
 
     private async Task OnUnsolvedSupportPostCreated(SocketThreadChannel thread)
     {
@@ -132,6 +154,56 @@ public class SolvedPostsService : IService, IInitializableService
         var button = new ComponentBuilder().WithButton("Mark as Solved", SolvedButtonId, ButtonStyle.Success, Emoji.Parse(":white_check_mark:")).Build();
 
         await thread.SendMessageAsync(embed: embedMessage, components: button);
+    }
+
+    private async Task OnIgnoreTagAdded(Cacheable<SocketThreadChannel, ulong> cachedPost, SocketThreadChannel thread)
+    {
+        if (thread.IsLocked || thread.IsArchived) return;
+        if (thread.ParentChannel is not SocketForumChannel forumChannel) return;
+        if (!_registeredSolvedChannels.TryGetValue(forumChannel.Id, out var solvedChannel)) return;
+        if (thread.AppliedTags.Any(t => solvedChannel.SolvedTag == t)) return;
+        if (!thread.AppliedTags.Any(t => solvedChannel.IgnoreWithTags.Contains(t))) return;
+
+        IGuildUser updateUser = await GetModeratorThreadUpdated(thread) ?? thread.Owner?.GuildUser ?? await ((IGuild)thread.Guild).GetUserAsync(((IThreadChannel)thread).OwnerId);
+        if (!updateUser.GuildPermissions.ManageThreads) return; // Assuming Ignore Tags are all Moderator Required but might be appliable by everyone
+
+        var messages = await thread.GetMessagesAsync().FlattenAsync();
+        var message = messages.LastOrDefault(m => m.Author.Id == _bot.DiscordClient.CurrentUser.Id && m.Components.Count > 0);
+        if (message == null) return;
+
+        await thread.DeleteMessageAsync(message);
+    }
+
+    private async Task<IGuildUser?> GetModeratorThreadUpdated(SocketThreadChannel updatedPost)
+    {
+        await foreach (var logs in updatedPost.Guild.GetAuditLogsAsync(4, actionType: ActionType.ThreadUpdate))
+        {
+            var logEntry = logs?.FirstOrDefault(log =>
+            {
+                if (_lastAuditLog != null && log.Id <= _lastAuditLog) // AuditLog too old / Already consumed
+                    return false;
+
+                if (log.CreatedAt.DateTime.AddSeconds(30) < DateTime.Now) // AuditLog too old
+                    return false;
+
+                if (log.Data is not ThreadUpdateAuditLogData logData)
+                    return false;
+
+                if (logData.Thread == null) // Thread has been Deleted
+                    return false;
+
+                return logData.Thread.Id == updatedPost.Id;
+            });
+
+            if (logEntry == null)
+                continue;
+
+            _lastAuditLog = logEntry.Id;
+
+            return await ((IGuild)updatedPost.Guild).GetUserAsync(logEntry.User.Id);
+        }
+
+        return null;
     }
 
     private async Task OnMarkAsSolvedButton(SocketMessageComponent component)
@@ -180,7 +252,7 @@ public class SolvedPostsService : IService, IInitializableService
             message = messages.LastOrDefault(m => m.Author.Id == _bot.DiscordClient.CurrentUser.Id);
         }
 
-        await DeleteInactivePostNotification(channel);
+        await DeleteInactivePostNotification(thread, solvedChannel);
 
         var newTags = thread.AppliedTags.ToList();
         newTags.Add(solvedChannel.SolvedTag);


### PR DESCRIPTION
- Properly fixed the bot deleting non-stale notification messages by comparing the embeds description to the stale notification description.
- Made the bot delete it's first Solved information if a Ignored tag is added to the forum post.